### PR TITLE
page_parameter_name in configuration

### DIFF
--- a/core/pagination.md
+++ b/core/pagination.md
@@ -46,7 +46,8 @@ The name of the page parameter can be changed with the following configuration:
 
 api_platform:
     collection:
-        page_parameter_name: _page
+        pagination:
+            page_parameter_name: _page
 ```
 
 ## Disabling the Pagination


### PR DESCRIPTION
Hi,

'Unrecognized option "page_parameter_name" under "api_platform.collection'; the page_parameter_name needs to sit underneath:

```
api_platform:
    collection:
        pagination:
            page_parameter_name
```

Hope this helps!

Kind regards,
David